### PR TITLE
Add time related features issued in issue #2

### DIFF
--- a/src/main/java/com/test/custom/annotations/EstimateTime.java
+++ b/src/main/java/com/test/custom/annotations/EstimateTime.java
@@ -1,0 +1,12 @@
+package com.test.custom.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface EstimateTime {
+    int value();
+}

--- a/src/main/java/com/test/custom/annotations/PrintTime.java
+++ b/src/main/java/com/test/custom/annotations/PrintTime.java
@@ -1,0 +1,11 @@
+package com.test.custom.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface PrintTime {
+}

--- a/src/main/java/com/test/custom/data/CustomTestMethod.java
+++ b/src/main/java/com/test/custom/data/CustomTestMethod.java
@@ -1,21 +1,32 @@
 package com.test.custom.data;
 
+import com.test.custom.annotations.EstimateTime;
+import com.test.custom.annotations.PrintTime;
 import com.test.custom.annotations.Repeat;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 
 public class CustomTestMethod {
-    private int repeatCount;
+    private int repeatCount = 1;
+    private int estimateTime = 0;
+    private boolean printTime = false;
     private Method method;
+
 
     public CustomTestMethod(Method method) {
         if (method == null)
             throw new IllegalArgumentException("method parameter for Custom Test Method must not be null");
         this.method = method;
-        if (method.isAnnotationPresent(Repeat.class)) {
-            repeatCount = method.getDeclaredAnnotation(Repeat.class).value();
-        } else
-            repeatCount = 1;
+
+        for (Annotation annotation : method.getAnnotations()) {
+            if (annotation.annotationType().equals(Repeat.class))
+                repeatCount = method.getDeclaredAnnotation(Repeat.class).value();
+            else if (annotation.annotationType().equals(PrintTime.class))
+                printTime = true;
+            else if (annotation.annotationType().equals(EstimateTime.class))
+                estimateTime = method.getDeclaredAnnotation(EstimateTime.class).value();
+        }
     }
 
     public int getRepeatCount() {
@@ -24,6 +35,22 @@ public class CustomTestMethod {
 
     public void setRepeatCount(int repeatCount) {
         this.repeatCount = repeatCount;
+    }
+
+    public int getEstimateTime() {
+        return estimateTime;
+    }
+
+    public void setEstimateTime(int estimateTime) {
+        this.estimateTime = estimateTime;
+    }
+
+    public boolean isPrintTime() {
+        return printTime;
+    }
+
+    public void setPrintTime(boolean printTime) {
+        this.printTime = printTime;
     }
 
     public Method getMethod() {

--- a/src/main/java/com/test/custom/exceptions/EstimatedTimeOverException.java
+++ b/src/main/java/com/test/custom/exceptions/EstimatedTimeOverException.java
@@ -1,0 +1,12 @@
+package com.test.custom.exceptions;
+
+public class EstimatedTimeOverException extends Exception {
+    private long expectedTime;
+    private long elapsedTime;
+
+    public EstimatedTimeOverException(long expectedTime, long elapsedTime) {
+        super("Estimated time elapsed expected : [" + expectedTime + "ms] elapsed : [" + elapsedTime + "]");
+        this.expectedTime = expectedTime;
+        this.elapsedTime = elapsedTime;
+    }
+}

--- a/src/main/java/com/test/custom/runner/CustomRunner.java
+++ b/src/main/java/com/test/custom/runner/CustomRunner.java
@@ -1,6 +1,7 @@
 package com.test.custom.runner;
 
 import com.test.custom.data.CustomTestMethod;
+import com.test.custom.exceptions.EstimatedTimeOverException;
 import org.junit.Test;
 import org.junit.runner.Description;
 import org.junit.runner.Runner;
@@ -56,6 +57,7 @@ public class CustomRunner extends Runner {
         CustomTestMethod testMethod;
         Method method;
         Object testObject = null;
+        long startTime = 0, endTime = 0;
 
         //Get class instance
         try {
@@ -69,23 +71,40 @@ public class CustomRunner extends Runner {
         for (String methodName : testMethodMap.keySet()) {
             testMethod = testMethodMap.get(methodName);
             method = testMethod.getMethod();
-            System.out.println("Testing testcase[" + method.getName() + "]");
 
             for (int i = 0; i < testMethod.getRepeatCount(); i++) {
                 //fire started & invoke
                 runNotifier.fireTestStarted(Description.createTestDescription(testClass, methodName));
                 try {
+                    System.out.println("Testing testcase[" + method.getName() + "]");
+                    startTime = System.currentTimeMillis();
                     method.invoke(testObject);
                 } catch (InvocationTargetException ite) {
                     if (ite.getTargetException() instanceof AssertionError) {
                         System.out.println("Assertion failed");
-                    } else
+                        runNotifier.fireTestFailure(new Failure(Description.createTestDescription(testClass, methodName), ite.getCause()));
+                    } else {
+                        runNotifier.fireTestFailure(new Failure(Description.createTestDescription(testClass, methodName), ite));
                         ite.printStackTrace();
-                    runNotifier.fireTestFailure(new Failure(Description.createTestDescription(testClass, methodName), ite));
+                    }
+
                     continue;
                 } catch (IllegalArgumentException | IllegalAccessException e) {
                     e.printStackTrace();
                     runNotifier.fireTestFailure(new Failure(Description.createTestDescription(testClass, methodName), e));
+                    continue;
+                } finally {
+                    endTime = System.currentTimeMillis();
+                    if (testMethod.isPrintTime())
+                        System.out.println("Test time for method [" + methodName + "] : " + (endTime - startTime));
+                }
+
+                //Check estimated time declared by @EstimateTime. If it elapsed, throw test failure.
+                if (testMethod.getEstimateTime() > 0 && (endTime - startTime) > testMethod.getEstimateTime()) {
+                    System.out.println("Test time exceeded estimated time. [Estimated time : " + testMethod.getEstimateTime() +
+                            "] [Elapsed time : " + (endTime - startTime) + "]");
+                    runNotifier.fireTestFailure(new Failure(Description.createTestDescription(testClass, methodName),
+                            new EstimatedTimeOverException(testMethod.getEstimateTime(), (endTime - startTime))));
                     continue;
                 }
                 //If invoke was successful, fire finished

--- a/src/test/java/TestCustomRunner.java
+++ b/src/test/java/TestCustomRunner.java
@@ -1,3 +1,5 @@
+import com.test.custom.annotations.EstimateTime;
+import com.test.custom.annotations.PrintTime;
 import com.test.custom.annotations.Repeat;
 import com.test.custom.runner.CustomRunner;
 import org.junit.Assert;
@@ -21,5 +23,14 @@ public class TestCustomRunner {
     @Repeat(2)
     public void test2() {
         System.out.println("test2");
+    }
+
+    @Test
+    @EstimateTime(9)
+    @PrintTime
+    public void test3() {
+        for (int i = 0; i < 100000000; i++) {
+
+        }
     }
 }


### PR DESCRIPTION
Description :
Added time related feature issued in issue #2
- PrintTime annotation for logging test time in ms
- EstimateTime annotation to make tests fail when it takes longer than declared estimation time.

Change content:
- annotations/EstimateTime.java : Declaration of EstimateTime annotation.
- annotations/PrintTime.java : Declaration of PrintTime annotation.
- data/CustomTestMethod : 1. Added estimation time and print time parameter in CustomTestMethod pojo class
                          2. Added annotation iteration logic
- exceptions/EstimatedTimeOverException : Added custom exception which is thrown when estimated time for a test case exceeds.
- runner/CustomRunner : 1. Added time measuring logic
                        2. Added time related logs
- test/java/TestCustomRunner : Added test3 for testing EstimateTime & PrintTime annotations

Closes Issue #2 

