### PR TITLE
Add test method ordering feature issued at issue #4

### DIFF
--- a/src/main/java/com/test/custom/annotations/TestOrder.java
+++ b/src/main/java/com/test/custom/annotations/TestOrder.java
@@ -1,0 +1,11 @@
+package com.test.custom.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestOrder {
+    enum OrderType {DEFAULT, ASCEND, DESCEND}
+
+    OrderType value() default OrderType.DEFAULT;
+}

--- a/src/main/java/com/test/custom/runner/CustomRunner.java
+++ b/src/main/java/com/test/custom/runner/CustomRunner.java
@@ -1,5 +1,6 @@
 package com.test.custom.runner;
 
+import com.test.custom.annotations.TestOrder;
 import com.test.custom.data.CustomTestMethod;
 import org.junit.Test;
 import org.junit.runner.Description;
@@ -9,6 +10,8 @@ import org.junit.runner.notification.RunNotifier;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 
@@ -64,9 +67,19 @@ public class CustomRunner extends Runner {
             System.out.println("Error instanciating testClass object");
             e.printStackTrace();
         }
+        ArrayList<String> keyList = new ArrayList<String>(testMethodMap.keySet());
+
+        //Sort method list
+        if (testClass.isAnnotationPresent(TestOrder.class)) {
+            TestOrder testOrder = (TestOrder) testClass.getDeclaredAnnotation(TestOrder.class);
+            if (testOrder.value() == TestOrder.OrderType.ASCEND)
+                Collections.sort(keyList);
+            else if (testOrder.value() == TestOrder.OrderType.DESCEND)
+                Collections.sort(keyList, Collections.reverseOrder());
+        }
 
         //iterate methods
-        for (String methodName : testMethodMap.keySet()) {
+        for (String methodName : keyList) {
             testMethod = testMethodMap.get(methodName);
             method = testMethod.getMethod();
             System.out.println("Testing testcase[" + method.getName() + "]");

--- a/src/test/java/TestCustomRunner.java
+++ b/src/test/java/TestCustomRunner.java
@@ -1,10 +1,12 @@
 import com.test.custom.annotations.Repeat;
+import com.test.custom.annotations.TestOrder;
 import com.test.custom.runner.CustomRunner;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(CustomRunner.class)
+@TestOrder(TestOrder.OrderType.ASCEND)
 public class TestCustomRunner {
 
     @Test


### PR DESCRIPTION
Description :
Added test method ordering feature which can be used by annotating test class with "@TestOrder()"
currently supported ordering types are :
1. OrderType.DEFAULT : No ordering is applied to test runner
2. OrderType.ASCEND : Order test methods by name in ascending order
3. OrderType.DESCEND : Order test methods by name in descending order

Change content:
- annotations/TestOrder : Added TestOrder class to declare "@TestOrder" as annotation
- runner/CustomRunner : Added logic which checks "@TestOrder" annotation presents in test class,
and sorts test method name list in corresponding order given by annotation
- test/java/TestCustomRunner : Added @TestOrder annotation sample

Closes issue #4 