### PR TITLE
Add Group/RunGroup feature

### DIFF
--- a/src/main/java/com/test/custom/annotations/Group.java
+++ b/src/main/java/com/test/custom/annotations/Group.java
@@ -1,0 +1,12 @@
+package com.test.custom.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Group {
+    String value() default "";
+}

--- a/src/main/java/com/test/custom/annotations/RunGroup.java
+++ b/src/main/java/com/test/custom/annotations/RunGroup.java
@@ -1,0 +1,9 @@
+package com.test.custom.annotations;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+public @interface RunGroup {
+    String value() default "";
+}

--- a/src/main/java/com/test/custom/data/CustomTestMethod.java
+++ b/src/main/java/com/test/custom/data/CustomTestMethod.java
@@ -1,6 +1,7 @@
 package com.test.custom.data;
 
 import com.test.custom.annotations.EstimateTime;
+import com.test.custom.annotations.Group;
 import com.test.custom.annotations.PrintTime;
 import com.test.custom.annotations.Repeat;
 
@@ -12,7 +13,7 @@ public class CustomTestMethod {
     private int estimateTime = 0;
     private boolean printTime = false;
     private Method method;
-
+    private String groupName = "";
 
     public CustomTestMethod(Method method) {
         if (method == null)
@@ -26,6 +27,8 @@ public class CustomTestMethod {
                 printTime = true;
             else if (annotation.annotationType().equals(EstimateTime.class))
                 estimateTime = method.getDeclaredAnnotation(EstimateTime.class).value();
+            else if (annotation.annotationType().equals(Group.class))
+                groupName = method.getDeclaredAnnotation(Group.class).value();
         }
     }
 
@@ -57,7 +60,17 @@ public class CustomTestMethod {
         return method;
     }
 
+    public String getGroupName() {
+        return groupName;
+    }
+
+    public void setGroupName(String groupName) {
+        this.groupName = groupName;
+    }
+
     public void setMethod(Method method) {
         this.method = method;
     }
+
+
 }

--- a/src/test/java/TestCustomRunner.java
+++ b/src/test/java/TestCustomRunner.java
@@ -1,18 +1,17 @@
-import com.test.custom.annotations.EstimateTime;
-import com.test.custom.annotations.PrintTime;
-import com.test.custom.annotations.Repeat;
-import com.test.custom.annotations.TestOrder;
+import com.test.custom.annotations.*;
 import com.test.custom.runner.CustomRunner;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(CustomRunner.class)
+@RunGroup("A")
 @TestOrder(TestOrder.OrderType.ASCEND)
 public class TestCustomRunner {
 
     @Test
     @Repeat(10)
+    @Group("A")
     public void test1() {
         int randValue;
         System.out.println("test1");
@@ -23,6 +22,7 @@ public class TestCustomRunner {
 
     @Test
     @Repeat(2)
+    @Group("A")
     public void test2() {
         System.out.println("test2");
     }
@@ -30,6 +30,7 @@ public class TestCustomRunner {
     @Test
     @EstimateTime(9)
     @PrintTime
+    @Group("B")
     public void test3() {
         for (int i = 0; i < 100000000; i++) {
 


### PR DESCRIPTION
Description :
Added test method group feature to execute grouped test cases in a single test class.
Usage : Set test method group by using `@Group` annotation to test method. In order to run specific test group in a test class,
add `@RunGroup` annotation to test class.
ex)
```
@RunGroup("A")
public class TestClass {
     @Group("A")
     public void test1() {
          ...
     }

     @Group("B")
     public void test2() {
          ...
     }

     @Group("A")
     public void test3() {
          ...
     }
}
```
If user runs TestClass in following example,  `test1()` and `test3()` will be executed.

Change content:
- annotations/Group.java : Declaration of Group annotation
- annotations/RunGroup.java : Declaration of RunGroup annotation
- data/CustomTestMethod : Added groupName parameter for CustomTestMethods
- runner/CustomRunner : If RunGroup is declared in target test class, check for Group when mapping methods.

Closes Issue #14 