### PR TITLE
Add BeforeMethod & AfterMethod issued in #11

### DIFF
--- a/src/main/java/com/test/custom/annotations/AfterMethod.java
+++ b/src/main/java/com/test/custom/annotations/AfterMethod.java
@@ -1,0 +1,12 @@
+package com.test.custom.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface AfterMethod {
+    String value();
+}

--- a/src/main/java/com/test/custom/annotations/AfterMethod.java
+++ b/src/main/java/com/test/custom/annotations/AfterMethod.java
@@ -8,5 +8,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface AfterMethod {
-    String value();
+    String[] value() default {};
 }

--- a/src/main/java/com/test/custom/annotations/BeforeMethod.java
+++ b/src/main/java/com/test/custom/annotations/BeforeMethod.java
@@ -8,5 +8,5 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface BeforeMethod {
-    String value();
+    String[] value() default {};
 }

--- a/src/main/java/com/test/custom/annotations/BeforeMethod.java
+++ b/src/main/java/com/test/custom/annotations/BeforeMethod.java
@@ -1,0 +1,12 @@
+package com.test.custom.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface BeforeMethod {
+    String value();
+}

--- a/src/main/java/com/test/custom/data/CustomTestMethod.java
+++ b/src/main/java/com/test/custom/data/CustomTestMethod.java
@@ -12,6 +12,8 @@ public class CustomTestMethod {
     private int estimateTime = 0;
     private boolean printTime = false;
     private Method method;
+    private Method beforeMethod = null;
+    private Method afterMethod = null;
 
 
     public CustomTestMethod(Method method) {
@@ -53,6 +55,22 @@ public class CustomTestMethod {
         this.printTime = printTime;
     }
 
+    public Method getBeforeMethod() {
+        return beforeMethod;
+    }
+
+    public void setBeforeMethod(Method beforeMethod) {
+        this.beforeMethod = beforeMethod;
+    }
+
+    public Method getAfterMethod() {
+        return afterMethod;
+    }
+
+    public void setAfterMethod(Method afterMethod) {
+        this.afterMethod = afterMethod;
+    }
+
     public Method getMethod() {
         return method;
     }
@@ -60,4 +78,6 @@ public class CustomTestMethod {
     public void setMethod(Method method) {
         this.method = method;
     }
+
+
 }

--- a/src/main/java/com/test/custom/runner/CustomRunner.java
+++ b/src/main/java/com/test/custom/runner/CustomRunner.java
@@ -59,15 +59,19 @@ public class CustomRunner extends Runner {
 
         //re-iterate methods to add Before/AfterMethods to test methods
         for (Method method : testClass.getMethods()) {
-            String testMethodName;
+            String[] testMethodList;
             if (method.isAnnotationPresent(AfterMethod.class)) {
-                testMethodName = method.getDeclaredAnnotation(AfterMethod.class).value();
-                if (testMethodMap.get(testMethodName) != null)
-                    testMethodMap.get(testMethodName).setAfterMethod(method);
+                testMethodList = method.getDeclaredAnnotation(AfterMethod.class).value();
+                for (String testMethodName : testMethodList) {
+                    if (testMethodMap.get(testMethodName) != null)
+                        testMethodMap.get(testMethodName).setAfterMethod(method);
+                }
             } else if (method.isAnnotationPresent(BeforeMethod.class)) {
-                testMethodName = method.getDeclaredAnnotation(BeforeMethod.class).value();
-                if (testMethodMap.get(testMethodName) != null)
-                    testMethodMap.get(testMethodName).setBeforeMethod(method);
+                testMethodList = method.getDeclaredAnnotation(BeforeMethod.class).value();
+                for (String testMethodName : testMethodList) {
+                    if (testMethodMap.get(testMethodName) != null)
+                        testMethodMap.get(testMethodName).setBeforeMethod(method);
+                }
             }
         }
     }

--- a/src/test/java/TestCustomRunner.java
+++ b/src/test/java/TestCustomRunner.java
@@ -1,7 +1,4 @@
-import com.test.custom.annotations.EstimateTime;
-import com.test.custom.annotations.PrintTime;
-import com.test.custom.annotations.Repeat;
-import com.test.custom.annotations.TestOrder;
+import com.test.custom.annotations.*;
 import com.test.custom.runner.CustomRunner;
 import org.junit.Assert;
 import org.junit.Test;
@@ -34,5 +31,19 @@ public class TestCustomRunner {
         for (int i = 0; i < 100000000; i++) {
 
         }
+    }
+
+    @BeforeMethod("test1")
+    public void testBefore() {
+        System.out.println(">>>>>>>>>>>>");
+        System.out.println("Before test1");
+        System.out.println(">>>>>>>>>>>>");
+    }
+
+    @AfterMethod("test1")
+    public void testAfter() {
+        System.out.println("<<<<<<<<<<<<");
+        System.out.println("After test1");
+        System.out.println("<<<<<<<<<<<<");
     }
 }

--- a/src/test/java/TestCustomRunner.java
+++ b/src/test/java/TestCustomRunner.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(CustomRunner.class)
-@RunGroup("A")
 @TestOrder(TestOrder.OrderType.ASCEND)
 public class TestCustomRunner {
 
@@ -37,17 +36,17 @@ public class TestCustomRunner {
         }
     }
 
-    @BeforeMethod("test1")
+    @BeforeMethod({"test1", "test2"})
     public void testBefore() {
         System.out.println(">>>>>>>>>>>>");
-        System.out.println("Before test1");
+        System.out.println("Before method");
         System.out.println(">>>>>>>>>>>>");
     }
 
-    @AfterMethod("test1")
+    @AfterMethod({"test2", "test3"})
     public void testAfter() {
         System.out.println("<<<<<<<<<<<<");
-        System.out.println("After test1");
+        System.out.println("After method");
         System.out.println("<<<<<<<<<<<<");
     }
 }


### PR DESCRIPTION
Add `@BeforeMethod` and `@AfterMethod` feature which sets pre-executed and post-executed methods to specified methods.
ex)
 @BeforeMethod({"test1", "test2"})
    public void testBefore() {
              ...
    } 
-> This method will be executed before testing `test1()` and `test2()

    @AfterMethod({"test2", "test3"})
    public void testAfter() {
            ...
    }
-> This method will be executed after testing `test2()` and `test3()